### PR TITLE
Set clahub context on combined status API

### DIFF
--- a/app/models/push_status_checker.rb
+++ b/app/models/push_status_checker.rb
@@ -37,7 +37,8 @@ class PushStatusChecker
     GithubRepos.new(repo_agreement.user).set_status(@push.user_name, @push.repo_name, sha = commit.id, {
       state: state,
       target_url: target_url,
-      description: STATUS_DESCRIPTIONS[state]
+      description: STATUS_DESCRIPTIONS[state],
+      context: "clahub"
     })
   end
 

--- a/spec/acceptance/sign_agreement_spec.rb
+++ b/spec/acceptance/sign_agreement_spec.rb
@@ -143,7 +143,8 @@ feature "Agreeing to a CLA" do
     status_params = {
       state: status,
       target_url: "#{HOST}/agreements/#{user_name}/#{repo_name}",
-      description: PushStatusChecker::STATUS_DESCRIPTIONS[status]
+      description: PushStatusChecker::STATUS_DESCRIPTIONS[status],
+      context: "clahub"
     }
 
     expect(a_request(:post, status_url).with(body: status_params.to_json)).to have_been_made

--- a/spec/requests/repo_hooks_spec.rb
+++ b/spec/requests/repo_hooks_spec.rb
@@ -37,7 +37,8 @@ describe 'receiving github repo webhook callbacks' do
     status_params = {
       state: 'success',
       target_url: "#{HOST}/agreements/jasonm/mangostickyrice",
-      description: 'All contributors have signed the Contributor License Agreement.'
+      description: 'All contributors have signed the Contributor License Agreement.',
+      context: "clahub"
     }
     expect(a_request(:post, status_url).with(body: status_params.to_json)).to have_been_made
   end
@@ -56,7 +57,8 @@ describe 'receiving github repo webhook callbacks' do
     status_params = {
       state: 'failure',
       target_url: "#{HOST}/agreements/jasonm/mangostickyrice",
-      description: 'Not all contributors have signed the Contributor License Agreement.'
+      description: 'Not all contributors have signed the Contributor License Agreement.',
+      context: "clahub"
     }
     expect(a_request(:post, status_url).with(body: status_params.to_json)).to have_been_made
   end
@@ -81,7 +83,8 @@ describe 'receiving github repo webhook callbacks' do
     status_params = {
       state: 'failure',
       target_url: "#{HOST}/agreements/jasonm/mangostickyrice",
-      description: 'Not all contributors have signed the Contributor License Agreement.'
+      description: 'Not all contributors have signed the Contributor License Agreement.',
+      context: "clahub"
     }
     expect(a_request(:post, status_url).with(body: status_params.to_json)).to have_been_made
   end
@@ -107,7 +110,8 @@ describe 'receiving github repo webhook callbacks' do
     status_params = {
       state: 'success',
       target_url: "#{HOST}/agreements/jasonm/mangostickyrice",
-      description: 'All contributors have signed the Contributor License Agreement.'
+      description: 'All contributors have signed the Contributor License Agreement.',
+      context: "clahub"
     }
     expect(a_request(:post, status_url).with(body: status_params.to_json)).to have_been_made
   end


### PR DESCRIPTION
This _should_ set the combined status context as discussed in https://github.com/clahub/clahub/issues/27.
