### PR TITLE
Add GitHubLimited strategy to avoid using public_repo scope on GitHub

### DIFF
--- a/app/controllers/github_limited_oauth_controller.rb
+++ b/app/controllers/github_limited_oauth_controller.rb
@@ -1,0 +1,2 @@
+class GithubLimitedOauthController < GithubOauthController
+end

--- a/app/views/agreements/show.html.erb
+++ b/app/views/agreements/show.html.erb
@@ -36,7 +36,7 @@
       <% end %>
     <% end %>
   <% else %>
-    <a id="sign-in-to-agree" href="/auth/github">Sign in with GitHub to agree to this CLA &raquo;</a>
+    <a id="sign-in-to-agree" href="/auth/github_limited">Sign in with GitHub to agree to this CLA &raquo;</a>
   <% end %>
 </div>
 

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,10 +1,23 @@
+OmniAuth.config.add_camelization 'github_limited', 'GitHubLimited'
+
+module OmniAuth
+  module Strategies
+    class GitHubLimited < GitHub
+      def name
+        "github_limited"
+      end
+    end
+  end
+end
+
 if Rails.env.development?
-  if ENV['GITHUB_KEY'].blank? || ENV['GITHUB_SECRET'].blank?
-    raise "Provide ENV['GITHUB_KEY'] and ENV['GITHUB_SECRET']"
+  if ENV['GITHUB_KEY'].blank? || ENV['GITHUB_SECRET'].blank? || ENV['GITHUB_LIMITED_KEY'].blank? || ENV['GITHUB_LIMITED_SECRET'].blank?
+    raise "Provide ENV['GITHUB_KEY'], ENV['GITHUB_SECRET'], ENV['GITHUB_LIMITED_KEY'] and ENV['GITHUB_LIMITED_SECRET']"
   end
 end
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :developer unless Rails.env.production?
   provider :github, ENV['GITHUB_KEY'], ENV['GITHUB_SECRET'], scope: "public_repo"
+  provider :github_limited, ENV['GITHUB_LIMITED_KEY'], ENV['GITHUB_LIMITED_SECRET'], scope: "(no scope)"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Clahub::Application.routes.draw do
   match "/pages/*id" => 'pages#show', as: :page, format: false
 
   match 'auth/github/callback' => 'github_oauth#callback', :as => :github_oauth_callback
+  match 'auth/github_limited/callback' => 'github_limited_oauth#callback', :as => :github_limited_oauth_callback
   match 'auth/failure' => 'github_oauth#failure'
   match 'sign_out' => 'sessions#destroy', :as => :sign_out
 


### PR DESCRIPTION
This branch uses a separate OmniAuth strategy so that it only requires "no scope" permissions from the user's GitHub account.

Should solve #54 and #68
