### PR TITLE
Fix dotenv

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'paul_revere'
 gem 'kramdown'
 gem 'newrelic_rpm'
 gem 'rack-ssl-enforcer'
+gem 'dotenv'
 
 group :development do
   gem 'pry'
@@ -42,7 +43,6 @@ end
 group :test, :development do
   gem 'rspec-rails', '~> 2.0'
   gem 'simplecov', require: false
-  gem 'dotenv'
   gem 'guard-livereload'
 end
 


### PR DESCRIPTION
When trying to deploy it on Heroku I got this error:

```
       Could not detect rake tasks
       ensure you can run `$ bundle exec rake -P` against your app with no environment variables present
       and using the production group of your Gemfile.
       This may be intentional, if you expected rake tasks to be run
       cancel the build (CTRL+C) and fix the error then commit the fix:
       rake aborted!
       LoadError: cannot load such file -- dotenv
       /tmp/build_1f06354b5bb66e9e880946825afa31fa/config/application.rb:70:in `require'
       /tmp/build_1f06354b5bb66e9e880946825afa31fa/config/application.rb:70:in `<top (required)>'
       /tmp/build_1f06354b5bb66e9e880946825afa31fa/Rakefile:5:in `require'
       /tmp/build_1f06354b5bb66e9e880946825afa31fa/Rakefile:5:in `<top (required)>'
       /tmp/build_1f06354b5bb66e9e880946825afa31fa/vendor/bundle/ruby/2.1.0/gems/rake-10.3.2/lib/rake/rake_module.rb:28:in `load'
       /tmp/build_1f06354b5bb66e9e880946825afa31fa/vendor/bundle/ruby/2.1.0/gems/rake-10.3.2/lib/rake/rake_module.rb:28:in `load_rakefile'
       /tmp/build_1f06354b5bb66e9e880946825afa31fa/vendor/bundle/ruby/2.1.0/gems/rake-10.3.2/lib/rake/application.rb:687:in `raw_load_rakefile'
       /tmp/build_1f06354b5bb66e9e880946825afa31fa/vendor/bundle/ruby/2.1.0/gems/rake-10.3.2/lib/rake/application.rb:94:in `block in load_rakefile'
       /tmp/build_1f06354b5bb66e9e880946825afa31fa/vendor/bundle/ruby/2.1.0/gems/rake-10.3.2/lib/rake/application.rb:176:in `standard_exception_handling'
       /tmp/build_1f06354b5bb66e9e880946825afa31fa/vendor/bundle/ruby/2.1.0/gems/rake-10.3.2/lib/rake/application.rb:93:in `load_rakefile'
       /tmp/build_1f06354b5bb66e9e880946825afa31fa/vendor/bundle/ruby/2.1.0/gems/rake-10.3.2/lib/rake/application.rb:77:in `block in run'
       /tmp/build_1f06354b5bb66e9e880946825afa31fa/vendor/bundle/ruby/2.1.0/gems/rake-10.3.2/lib/rake/application.rb:176:in `standard_exception_handling'
       /tmp/build_1f06354b5bb66e9e880946825afa31fa/vendor/bundle/ruby/2.1.0/gems/rake-10.3.2/lib/rake/application.rb:75:in `run'
       /tmp/build_1f06354b5bb66e9e880946825afa31fa/vendor/bundle/ruby/2.1.0/gems/rake-10.3.2/bin/rake:33:in `<top (required)>'
       vendor/bundle/bin/rake:16:in `load'
       vendor/bundle/bin/rake:16:in `<main>'
```

I fixed this adding `dotenv` to `Gemfile`, but I don't know if there is a better way to fix it.
