### PR TITLE
Organization-level agreements

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,6 +3,10 @@ module ApplicationHelper
     "#{repo.owner.login}/#{repo.name}"
   end
 
+  def org_slash_all(org)
+    "#{org.login}/" + GithubRepos::ALL_REPOS
+  end
+
   def body_class
     qualified_controller_name = controller.controller_path.gsub('/','-')
     "#{qualified_controller_name} #{qualified_controller_name}-#{controller.action_name}"

--- a/app/jobs/check_open_pulls_job.rb
+++ b/app/jobs/check_open_pulls_job.rb
@@ -7,6 +7,7 @@ class CheckOpenPullsJob
     @owner = options[:owner]
     @user_name = options[:user_name]
     @repo_name = options[:repo_name]
+    @other_repo_names = options[:other_repo_names]
   end
 
   def run
@@ -20,29 +21,39 @@ class CheckOpenPullsJob
   private
 
   def pushes
-    pull_mashes.map do |pull_mash|
-      commit_mashes = github_repos.get_pull_commits(
-        @user_name, @repo_name, pull_mash.number)
-
-      # TODO this is a weird adapter, unweird it
-      GithubPush.new({
-        repository: {
-          owner: { name: @user_name },
-          name: @repo_name
-        },
-        commits: commit_mashes.map { |mash|
-          # TODO: Add test case for no author only committer on this phase
-          commit_hash = { id: mash.sha }
-          commit_hash[:author] = { username: mash.author.login } if mash.author
-          commit_hash[:committer] = { username: mash.committer.login } if mash.committer
-          commit_hash
-        }
-      }.to_json)
+    repos = []
+    if @repo_name == GithubRepos::ALL_REPOS
+      repos = @other_repo_names
+    else
+      repos << @repo_name
     end
+    mashes = []
+    for repo in repos
+      mashes += pull_mashes(repo).map do |pull_mash|
+        commit_mashes = github_repos.get_pull_commits(
+          @user_name, repo, pull_mash.number)
+  
+        # TODO this is a weird adapter, unweird it
+        GithubPush.new({
+          repository: {
+            owner: { name: @user_name },
+            name: repo
+          },
+          commits: commit_mashes.map { |mash|
+            # TODO: Add test case for no author only committer on this phase
+            commit_hash = { id: mash.sha }
+            commit_hash[:author] = { username: mash.author.login } if mash.author
+            commit_hash[:committer] = { username: mash.committer.login } if mash.committer
+            commit_hash
+          }
+        }.to_json)
+      end
+    end
+    return mashes
   end
 
-  def pull_mashes
-    github_repos.get_pulls(@user_name, @repo_name)
+  def pull_mashes(repo)
+    github_repos.get_pulls(@user_name, repo)
   end
 
   def github_repos

--- a/app/models/push_status_checker.rb
+++ b/app/models/push_status_checker.rb
@@ -32,7 +32,7 @@ class PushStatusChecker
   end
 
   def mark(commit, state)
-    target_url = "#{HOST}/agreements/#{@push.user_name}/#{@push.repo_name}"
+    target_url = "#{HOST}/agreements/#{@push.user_name}/#{repo_agreement.repo_name}"
 
     GithubRepos.new(repo_agreement.user).set_status(@push.user_name, @push.repo_name, sha = commit.id, {
       state: state,
@@ -68,9 +68,14 @@ class PushStatusChecker
   end
 
   def repo_agreement
-    @repo_agreement ||= Agreement.where({
-      user_name: @push.user_name,
-      repo_name: @push.repo_name
-    }).first
+    #@repo_agreement ||= Agreement.where({
+    #  user_name: @push.user_name,
+    #  repo_name: @push.repo_name
+    #}).first
+    for a in Agreement.where({ user_name: @push.user_name })
+      if a['repo_name'] == @push.repo_name || (a['repo_name'] == GithubRepos::ALL_REPOS && a['other_repo_names'].include?(@push.repo_name))
+        return a
+      end
+    end
   end
 end

--- a/app/views/agreements/new.html.erb
+++ b/app/views/agreements/new.html.erb
@@ -6,6 +6,11 @@
   <%= form.label :user_name_repo_name, "Choose a repo:" %>
   <select name="agreement[user_name_repo_name]" id="user-name-repo-name" class="select-chosen" data-placeholder="GitHub repositories for <%= current_user.nickname %>" style="width:350px;" tabindex="1">
     <option value=""></option>
+    <% @orgs.each do |org| %>
+      <option value="<%= org_slash_all(org) %>">
+        <%= org_slash_all(org) %>
+      </option>
+    <% end %>
     <% @repos.each do |repo| %>
       <option value="<%= owner_slash_name(repo) %>">
         <%= owner_slash_name(repo) %>

--- a/db/migrate/20140904025815_add_other_repo_names_to_agreements.rb
+++ b/db/migrate/20140904025815_add_other_repo_names_to_agreements.rb
@@ -1,0 +1,5 @@
+class AddOtherRepoNamesToAgreements < ActiveRecord::Migration
+  def change
+    add_column :agreements, :other_repo_names, :string
+  end
+end

--- a/db/migrate/20140904025911_add_other_github_repo_hook_ids_to_agreements.rb
+++ b/db/migrate/20140904025911_add_other_github_repo_hook_ids_to_agreements.rb
@@ -1,0 +1,5 @@
+class AddOtherGithubRepoHookIdsToAgreements < ActiveRecord::Migration
+  def change
+    add_column :agreements, :other_github_repo_hook_ids, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130218033834) do
+ActiveRecord::Schema.define(:version => 20140904025911) do
 
   create_table "agreement_fields", :force => true do |t|
     t.integer  "agreement_id"
@@ -28,9 +28,11 @@ ActiveRecord::Schema.define(:version => 20130218033834) do
     t.string   "repo_name"
     t.text     "text"
     t.integer  "user_id"
-    t.datetime "created_at",          :null => false
-    t.datetime "updated_at",          :null => false
+    t.datetime "created_at",                 :null => false
+    t.datetime "updated_at",                 :null => false
     t.integer  "github_repo_hook_id"
+    t.string   "other_repo_names"
+    t.string   "other_github_repo_hook_ids"
   end
 
   add_index "agreements", ["user_id"], :name => "index_licenses_on_user_id"

--- a/lib/github_repos.rb
+++ b/lib/github_repos.rb
@@ -1,12 +1,18 @@
 class GithubRepos
   REPOS_PER_PAGE = 100 # the max
 
+  ALL_REPOS = "@ALL"
+
   def initialize(user)
     @github ||= Github.new(oauth_token: user.oauth_token, auto_pagination: true)
   end
 
   def repos
     [user_repos, org_repos].flatten
+  end
+
+  def orgs
+    @github.orgs.list
   end
 
   def create_hook(user_name, repo_name, hook_inputs)
@@ -28,21 +34,24 @@ class GithubRepos
   def get_pull_commits(user_name, repo_name, pull_id)
     @github.pull_requests.commits(user_name, repo_name, pull_id)
   end
+
+  def org_repos(one_org='')
+    repos = []
+    @github.orgs.list.each do |org|
+      if one_org.empty? || one_org == org.login
+        @github.repos.list(org: org.login, per_page: REPOS_PER_PAGE).each do |repo|
+          if repo.permissions.admin
+            repos.push(repo)
+          end
+        end
+      end
+    end
+    repos
+  end
   private
 
   def user_repos
     @github.repos.list(per_page: REPOS_PER_PAGE).sort_by(&:name)
   end
 
-  def org_repos
-    repos = []
-    @github.orgs.list.each do |org|
-      @github.repos.list(org: org.login, per_page: REPOS_PER_PAGE).each do |repo|
-        if repo.permissions.admin
-          repos.push(repo)
-        end
-      end
-    end
-    repos
-  end
 end


### PR DESCRIPTION
This branch adds support for creating agreements that cover all the repos in an organization account. This adds a new ```$ORGANIZATION/@ALL``` entry to the repo drop-down menu that, when selected, allows users to create agreements for all the repositories in an organization they are administrators of.