### PR TITLE
Use entire commit history in a pull request

### DIFF
--- a/app/controllers/github_webhooks_controller.rb
+++ b/app/controllers/github_webhooks_controller.rb
@@ -8,6 +8,9 @@ class GithubWebhooksController < ApplicationController
     if event == 'push'
       payload = GithubPush.new(params[:payload])
       PushStatusChecker.new(payload).check_and_update
+    elsif event == 'pull_request'
+      payload = GithubPullRequest.new(params[:payload])
+      PullRequestStatusChecker.new(payload).check_and_update
     end
 
     render text: "OK", status: 200

--- a/app/models/agreement.rb
+++ b/app/models/agreement.rb
@@ -19,7 +19,8 @@ class Agreement < ActiveRecord::Base
       'name' => 'web',
       'config' => {
         'url' => "#{HOST}/repo_hook"
-      }
+      },
+      'events' => ['pull_request']
     }
 
     response = GithubRepos.new(self.user).create_hook(user_name, repo_name, hook_inputs)

--- a/app/models/github_pull_request.rb
+++ b/app/models/github_pull_request.rb
@@ -1,0 +1,29 @@
+class GithubPullRequest
+  def initialize(json)
+    @mash = Hashie::Mash.new(JSON.parse(json))
+  end
+
+  def repo_name
+    @mash.repository.try(:name)
+  end
+
+  def user_name
+    @mash.repository.try(:owner).try(:name)
+  end
+
+  def user_login
+    @mash.repository.try(:owner).try(:login)
+  end
+
+  def commits
+    @mash.commits || []
+  end
+
+  def action
+    @mash.action
+  end
+
+  def number
+    @mash.number
+  end
+end


### PR DESCRIPTION
This branch subscribes the hook handler to ```pull_request``` events, instead of push, so it can check that all the commits are done by CLA signees.

Solves #83 