### PR TITLE
Env vars

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -25,7 +25,7 @@ Migrate the database:
 Register for two new [GitHub applications](https://github.com/settings/applications/new), one will be used for project owner signups and one for contributors signups. From the applications' page, copy the client keys and secrets, and add it to the Heroku environment:
 
     heroku config:add GITHUB_KEY=aaa111bbb GITHUB_SECRET=ccc222ddd
-    heroku config:add GITHUB_LIMITED_KEY=aaa111bbb GITHUB_LIMTIED_SECRET=ccc222ddd
+    heroku config:add GITHUB_LIMITED_KEY=aaa111bbb GITHUB_LIMITED_SECRET=ccc222ddd
 
 The "limited" application will be used for the contributor signups. It will only be used for authorization and hence won't require any permissions to the contributor's account.
 

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'paul_revere'
 gem 'kramdown'
 gem 'newrelic_rpm'
 gem 'rack-ssl-enforcer'
-gem 'dotenv'
+gem 'dotenv-rails'
 
 group :development do
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,9 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.2.5)
     docile (1.1.3)
-    dotenv (0.10.0)
+    dotenv (1.0.2)
+    dotenv-rails (1.0.2)
+      dotenv (= 1.0.2)
     dynamic_form (1.1.4)
     em-websocket (0.5.0)
       eventmachine (>= 0.12.9)
@@ -277,7 +279,7 @@ DEPENDENCIES
   coffee-rails (~> 3.2.1)
   database_cleaner
   debugger-linecache (= 1.2.0)
-  dotenv
+  dotenv-rails
   dynamic_form
   factory_girl_rails
   github_api

--- a/config/application.rb
+++ b/config/application.rb
@@ -66,6 +66,3 @@ module Clahub
     config.assets.version = '1.0'
   end
 end
-
-require "dotenv"
-Dotenv.load

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -11,9 +11,10 @@ module OmniAuth
 end
 
 if Rails.env.development?
-  if ENV['GITHUB_KEY'].blank? || ENV['GITHUB_SECRET'].blank? || ENV['GITHUB_LIMITED_KEY'].blank? || ENV['GITHUB_LIMITED_SECRET'].blank?
-    raise "Provide ENV['GITHUB_KEY'], ENV['GITHUB_SECRET'], ENV['GITHUB_LIMITED_KEY'] and ENV['GITHUB_LIMITED_SECRET']"
+  missing = %w(GITHUB_KEY GITHUB_SECRET GITHUB_LIMITED_KEY GITHUB_LIMITED_SECRET).select do |key|
+    ENV[key].blank?
   end
+  raise "Provide #{missing.to_sentence}" if missing.any?
 end
 
 Rails.application.config.middleware.use OmniAuth::Builder do


### PR DESCRIPTION
I copied and pasted the environment variable names from the deploy docs and couldn't figure out why I was still getting the error about the configs not being set. This shows specifically which environment variable is missing, which helped me discover that there was a typo in the docs.

This also uses the `dotenv-rails` gem, which will automatically configure dotenv without any manual steps.