### PR TITLE
Mark all children of a failed commit as "failed"

### DIFF
--- a/spec/acceptance/sign_agreement_spec.rb
+++ b/spec/acceptance/sign_agreement_spec.rb
@@ -129,10 +129,11 @@ feature "Agreeing to a CLA" do
     expect_commit_status_to_be_set('the_owner', 'alpha', 'bbb222', 'success')
     expect_commit_status_to_be_set('the_owner', 'alpha', 'ccc333', 'failure')
     expect_commit_status_to_be_set('the_owner', 'beta',  'ddd444', 'failure')
-    expect_commit_status_to_be_set('the_owner', 'beta',  'eee555', 'failure')
+    expect_commit_status_to_be_set('the_owner', 'beta',  'eee555', 'ancestor_failure')
 
-    sign_agreement('the_owner', 'beta', 'caterina_committer')
-    expect_commit_status_to_be_set('the_owner', 'beta',  'eee555', 'success')
+    sign_agreement('the_owner', 'beta', 'nancy_no_signature')
+    expect_commit_status_to_be_set('the_owner', 'beta',  'ddd444', 'success')
+    expect_commit_status_to_be_set('the_owner', 'beta',  'eee555', 'failure')
   end
 
   def expect_commit_status_to_be_set(user_name, repo_name, sha, status)


### PR DESCRIPTION
Because a git history is modeled as a graph, a single commit cannot be
judged in isolation. When one commit fails the CLA check, none of its
children should be labeled as "passing". This is especially important in
the GitHub Pull Request UI because it reports the state of a given Pull
Request as the state of the final commit.

Resolves gh-28