### PR TITLE
Use only those `state` values recognized by GitHub

### DIFF
--- a/spec/acceptance/sign_agreement_spec.rb
+++ b/spec/acceptance/sign_agreement_spec.rb
@@ -136,15 +136,15 @@ feature "Agreeing to a CLA" do
     expect_commit_status_to_be_set('the_owner', 'beta',  'eee555', 'failure')
   end
 
-  def expect_commit_status_to_be_set(user_name, repo_name, sha, status)
+  def expect_commit_status_to_be_set(user_name, repo_name, sha, status_name)
     raise "no agreement made for repo" unless agreement = Agreement.find_by_user_name_and_repo_name(user_name, repo_name)
     raise "no oauth token for creator" unless oauth_token = agreement.user.oauth_token
 
     status_url = "https://api.github.com/repos/#{user_name}/#{repo_name}/statuses/#{sha}?access_token=#{oauth_token}"
     status_params = {
-      state: status,
+      state: CommitGroup::STATUS_TYPES[status_name]['state'],
       target_url: "#{HOST}/agreements/#{user_name}/#{repo_name}",
-      description: CommitGroup::STATUS_DESCRIPTIONS[status],
+      description: CommitGroup::STATUS_TYPES[status_name]['description'],
       context: "clahub"
     }
 


### PR DESCRIPTION
@jasonm I haven't verified this, but all signs suggest that there is a problem with my patch for gh-99. Little bit of egg on my face, but I'm hoping a quick fix makes up for it!

> GitHub recognizes a limited set of `state` values:
> 
> > Integrating with our Status API is simple. Each status includes a
> > state, a SHA, a repository, and an optional URL and description. The
> > state reflects whether or not a SHA (commit) is successful at that
> > point in time. The states we currently support are "pending",
> > "success", "failure", and "error". If the status provides a URL or
> > description, we display it in our UI.
>
> - source: GitHub Blog, "Commit Status API" [1]
>
> All failing statuses should specify their `state` value as "failure"
> regardless of the status description.
>
> [1] https://github.com/blog/1227-commit-status-api