### PR TITLE
Limit required access rights

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -19,6 +19,6 @@ end
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :developer unless Rails.env.production?
-  provider :github, ENV['GITHUB_KEY'], ENV['GITHUB_SECRET'], scope: "public_repo"
+  provider :github, ENV['GITHUB_KEY'], ENV['GITHUB_SECRET'], scope: "user:email,repo:status,admin:repo_hook,admin:org_hook,read:org"
   provider :github_limited, ENV['GITHUB_LIMITED_KEY'], ENV['GITHUB_LIMITED_SECRET'], scope: "(no scope)"
 end


### PR DESCRIPTION
@jasonm I don't have a deployed version of this application running, so I haven't been able to test this. Would you mind manually verifying that it works? Sorry, I know it's kind of a hassle, but I can't think of an automated way to ensure this actually works.

Commit message:

> When registering a new repository, only request permission for those
> actions required by this application. This includes:
> 
> > - `user:email` - Grants read access to a user’s email addresses.
> > - `repo:status` - Grants read/write access to public and private
> >   repository commit statuses. This scope is only necessary to grant
> >   other users or services access to private repository commit statuses
> >   without granting access to the code.
> > - `admin:repo_hook` - Grants read, write, ping, and delete access to
> >   hooks in public or private repositories.
> > - `admin:org_hook` - Grants read, write, ping, and delete access to
> >   organization hooks. **Note:** OAuth tokens will only be able to
> >   perform these actions on organization hooks which were created by
> >   the OAuth application. Personal access tokens will only be able to
> >   perform these actions on organization hooks created by a user.
> > - `read:org` - Read-only access to organization, teams, and
> >   membership.
>
> [1]
>
> ...and is facilitated by the OmniAuth Github gem:
> 
> > ### Scopes
> >
> > GitHub API v3 lets you set scopes to provide granular access to
> > different types of data:
> >
> >     use OmniAuth::Builder do
> >       provider :github, ENV['GITHUB_KEY'], ENV['GITHUB_SECRET'], scope: "user,repo,gist"
> >     end
>
> [2]
>
> [1] GitHub API Documentation - OAuth: Scopes
>     https://developer.github.com/v3/oauth/#scopes
> [2] OmniAuth-Github gem documentation
>     https://github.com/intridea/omniauth-github#scopes