### PR TITLE
Update Gemfile.lock for El Capitan

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,8 @@ GEM
     bootstrap-sass (2.3.2.2)
       sass (~> 3.2)
     builder (3.0.4)
-    capybara (2.2.1)
+    capybara (2.6.2)
+      addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
@@ -138,14 +139,14 @@ GEM
       treetop (~> 1.4.8)
     method_source (0.8.2)
     mime-types (1.25.1)
-    mini_portile (0.6.2)
-    multi_json (1.10.1)
+    mini_portile2 (2.0.0)
+    multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     newrelic_rpm (3.7.3.204)
-    nio4r (1.0.0)
-    nokogiri (1.6.5)
-      mini_portile (~> 0.6.0)
+    nio4r (1.2.1)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
     oauth2 (0.9.4)
       faraday (>= 0.8, < 0.10)
       jwt (~> 1.0)
@@ -166,7 +167,7 @@ GEM
     paul_revere (1.2)
       rails (>= 3.0)
     pg (0.17.1)
-    poltergeist (1.5.0)
+    poltergeist (1.9.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
@@ -181,7 +182,7 @@ GEM
     pry-remote (0.1.8)
       pry (~> 0.9)
       slop (~> 3.0)
-    rack (1.4.5)
+    rack (1.4.7)
     rack-cache (1.2)
       rack (>= 0.4)
     rack-canonical-host (0.0.9)
@@ -190,7 +191,7 @@ GEM
     rack-ssl (1.3.4)
       rack
     rack-ssl-enforcer (0.2.6)
-    rack-test (0.6.2)
+    rack-test (0.6.3)
       rack (>= 1.0)
     rails (3.2.19)
       actionmailer (= 3.2.19)
@@ -262,7 +263,9 @@ GEM
     webmock (1.17.4)
       addressable (>= 2.2.7)
       crack (>= 0.3.2)
-    websocket-driver (0.3.2)
+    websocket-driver (0.6.3)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -306,3 +309,6 @@ DEPENDENCIES
   thin
   uglifier (>= 1.0.3)
   webmock
+
+BUNDLED WITH
+   1.11.2


### PR DESCRIPTION
Several gems failed to work when setting up the project on El Capitan.
This updates the gems so the project will work on the most recent OS X.