### PR TITLE
update links to projects that use CLA

### DIFF
--- a/app/views/pages/why_cla.html.erb
+++ b/app/views/pages/why_cla.html.erb
@@ -40,11 +40,10 @@
 
 <ul>
   <li><a href="http://www.canonical.com/contributors">Canonical</a></li>
-  <li><a href="https://fedoraproject.org/wiki/Legal:Licenses/CLA">Fedora</a></li>
-  <li><a href="http://source.android.com/source/cla-individual.html">Android</a></li>
+  <li><a href="https://fedoraproject.org/wiki/Legal:Fedora_Project_Contributor_Agreement">Fedora</a></li>
+  <li><a href="https://cla.developers.google.com/about/google-individual">Android</a></li>
   <li><a href="http://mono-project.com/FAQ:_Licensing">Mono</a></li>
   <li><a href="http://www.apache.org/licenses/icla.txt">Apache</a></li>
-  <li><a href="http://nodejs.org/cla.html">NodeJS</a></li>
 </ul>
 
 <h2>Conclusion</h2>


### PR DESCRIPTION
remove node.js, which hasn't had one for a couple years