### PR TITLE
Fix #135 by ignoring web committers

### DIFF
--- a/app/models/commit_group.rb
+++ b/app/models/commit_group.rb
@@ -103,7 +103,7 @@ class CommitGroup
       contributors << author
     end
 
-    if commit.committer
+    if commit.committer && commit.committer.username != 'web-flow'
       committer_email = commit.committer.email
       committer_username = commit.committer.username
       committer = User.find_by_email_or_nickname(committer_email, committer_username)


### PR DESCRIPTION
GitHub specifies the commiter as being "web-flow" with an e-mail of NULL if you make a commit using the GitHub website. However the contributors information is properly included in the author section. Since copyright is with the author we've decided to ignore checking the web committer for CLA Hub purposes.