### PR TITLE
Stop saving signature OAuth tokens

### DIFF
--- a/app/controllers/github_limited_oauth_controller.rb
+++ b/app/controllers/github_limited_oauth_controller.rb
@@ -1,2 +1,10 @@
 class GithubLimitedOauthController < GithubOauthController
+	def user_for_auth(auth)
+	  User.find_or_create_for_github_oauth({
+	    name:        auth.info.name,
+	    nickname:    auth.info.nickname,
+	    email:       auth.info.email,
+	    uid:         auth.uid
+	  })
+	end
 end

--- a/app/controllers/github_oauth_controller.rb
+++ b/app/controllers/github_oauth_controller.rb
@@ -8,7 +8,7 @@ class GithubOauthController < ApplicationController
   end
 
   def failure
-    redirect_to home_url, alert: "You'll need to sign into GitHub.  Maybe next time?"
+    redirect_to home_url, alert: "You'll need to sign into GitHub. Maybe next time?"
   end
 
   private


### PR DESCRIPTION
If a user who is a maintainer of a repo later is signed out from CLAHub and signs in from a signature page their stored OAuth token is overwritten with one that has lesser permissions. This changes the behavior so we do not store the OAuth token from signatories since we should only need it for that session.

Resolves #134
Resolves #144