### PR TITLE
Fix link to source of CLA definition as blog down

### DIFF
--- a/app/views/pages/why_cla.html.erb
+++ b/app/views/pages/why_cla.html.erb
@@ -2,7 +2,7 @@
   <h1>What is a CLA and why do I care?</h1>
 </div>
 
-<p><cite>From Tony Guntharp’s <a href="http://fusion94.org/blog/2013/01/16/clahub-clas-done-right/">blog post on CLAs and CLAHub</a>:</cite></p>
+<p><cite>From Tony Guntharp’s <a href="https://web.archive.org/web/20160407161404/http://fusion94.org/blog/2013/01/16/clahub-clas-done-right/">blog post on CLAs and CLAHub</a>:</cite></p>
 
 <h2>Synopsis</h2>
 <p>First of all, what exactly is a Contributor License Agreement (hereafter referred to as CLA)?</p>


### PR DESCRIPTION
* Modfies the link to the original definition post to point to wayback machine, as blog is down right now
