### PR TITLE
✨ Add Umami analytics tracking

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Script from "next/script";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Providers } from "@/components/providers";
 import { Toaster } from "@/components/ui/sonner";
@@ -66,6 +67,12 @@ export default function RootLayout({
           </a>
           {children}
           <Toaster />
+          <Script
+            defer
+            src="https://analytics.damagelabs.io/script.js"
+            data-website-id="9f298471-93d0-49b1-9c48-88b3237e048d"
+            strategy="afterInteractive"
+          />
         </Providers>
       </body>
     </html>


### PR DESCRIPTION
## Summary
Add self-hosted Umami analytics to cla-hub.io.

## Changes
- **src/app/layout.tsx**: Added Next.js Script component with Umami tracking

## Test Plan
- [x] Script loads on page
- [x] Page views appear in Umami dashboard
- [x] Build passes